### PR TITLE
Support readonly mode

### DIFF
--- a/editor/css/diagram.css
+++ b/editor/css/diagram.css
@@ -6,6 +6,11 @@
   --glsp-foreground: #616161;
 }
 
+html,
+body {
+  overflow: hidden;
+}
+
 /* Graph */
 .sprotty-graph {
   background: var(--glsp-editor-background);

--- a/editor/css/tool-palette.css
+++ b/editor/css/tool-palette.css
@@ -138,7 +138,7 @@
 }
 
 .collapsible-palette {
-  overflow: hidden;
+  overflow: auto;
   transition: max-height 0.2s ease-out;
 }
 
@@ -155,6 +155,6 @@
   border: none;
   padding-left: 3px;
   width: 100%;
-  margin-left: 0;
+  margin: 0;
   box-sizing: border-box;
 }

--- a/editor/src/breakpoint/breakpoint.ts
+++ b/editor/src/breakpoint/breakpoint.ts
@@ -32,6 +32,7 @@ class BreakpointQuickAction implements QuickAction {
     public readonly title = 'Toggle Breakpoint',
     public readonly location = QuickActionLocation.Left,
     public readonly sorting = 'C',
-    public readonly action = new BreakpointAction(elementId)
+    public readonly action = new BreakpointAction(elementId),
+    public readonly readonlySupport = true
   ) {}
 }

--- a/editor/src/jump/action.ts
+++ b/editor/src/jump/action.ts
@@ -27,6 +27,7 @@ class JumpQuickAction implements QuickAction {
     public readonly title = 'Jump',
     public readonly location = QuickActionLocation.BottomLeft,
     public readonly sorting = 'A',
-    public readonly action = new JumpAction(elementId)
+    public readonly action = new JumpAction(elementId),
+    public readonly readonlySupport = true
   ) {}
 }

--- a/editor/src/quick-action/di.config.ts
+++ b/editor/src/quick-action/di.config.ts
@@ -1,7 +1,7 @@
 import '../../css/quick-action.css';
 
 import { configureActionHandler, GLSP_TYPES, TYPES } from '@eclipse-glsp/client';
-import { ContainerModule } from 'inversify';
+import { ContainerModule, interfaces } from 'inversify';
 
 import { ConnectQuickActionProvider, QuickActionEdgeCreationTool, QuickActionTriggerEdgeCreationAction } from './edge/edge-creation-tool';
 import { AutoAlignQuickActionProvider, DeleteQuickActionProvider, IVY_TYPES } from './quick-action';
@@ -11,13 +11,20 @@ const ivyQuickActionModule = new ContainerModule((bind, _unbind, isBound) => {
   bind(QuickActionUI).toSelf().inSingletonScope();
   bind(TYPES.IUIExtension).toService(QuickActionUI);
 
-  bind(QuickActionEdgeCreationTool).toSelf().inSingletonScope();
-  bind(GLSP_TYPES.ITool).toService(QuickActionEdgeCreationTool);
-  configureActionHandler({ bind, isBound }, QuickActionTriggerEdgeCreationAction.KIND, QuickActionEdgeCreationTool);
-
-  bind(IVY_TYPES.QuickActionProvider).to(DeleteQuickActionProvider);
-  bind(IVY_TYPES.QuickActionProvider).to(ConnectQuickActionProvider);
-  bind(IVY_TYPES.QuickActionProvider).to(AutoAlignQuickActionProvider);
+  configureQuickActionEdgeTool({ bind, isBound });
+  configureQuickActionProviders({ bind });
 });
+
+export function configureQuickActionEdgeTool(context: { bind: interfaces.Bind; isBound: interfaces.IsBound }): void {
+  context.bind(QuickActionEdgeCreationTool).toSelf().inSingletonScope();
+  context.bind(GLSP_TYPES.ITool).toService(QuickActionEdgeCreationTool);
+  configureActionHandler(context, QuickActionTriggerEdgeCreationAction.KIND, QuickActionEdgeCreationTool);
+}
+
+export function configureQuickActionProviders(context: { bind: interfaces.Bind }): void {
+  context.bind(IVY_TYPES.QuickActionProvider).to(DeleteQuickActionProvider);
+  context.bind(IVY_TYPES.QuickActionProvider).to(ConnectQuickActionProvider);
+  context.bind(IVY_TYPES.QuickActionProvider).to(AutoAlignQuickActionProvider);
+}
 
 export default ivyQuickActionModule;

--- a/editor/src/quick-action/quick-action.ts
+++ b/editor/src/quick-action/quick-action.ts
@@ -70,6 +70,7 @@ export interface QuickAction {
   location: QuickActionLocation;
   sorting: string;
   action: Action;
+  readonlySupport?: boolean;
 }
 
 class DeleteQuickAction implements QuickAction {

--- a/editor/src/tool-palette/di.config.ts
+++ b/editor/src/tool-palette/di.config.ts
@@ -1,11 +1,12 @@
 import '../../css/tool-palette.css';
 
-import { configureActionHandler, configureCommand, EnableDefaultToolsAction } from '@eclipse-glsp/client';
+import { configureActionHandler, configureCommand, EnableDefaultToolsAction, GLSP_TYPES } from '@eclipse-glsp/client';
 import { ContainerModule } from 'inversify';
 import { TYPES } from 'sprotty';
 
 import { EnableToolPaletteAction, ToolPalette } from './tool-palette';
 import { ToolPaletteFeedbackCommand } from './tool-palette-feedback';
+import { IvyMarqueeMouseTool } from './marquee-mouse-tool';
 
 const ivyToolPaletteModule = new ContainerModule((bind, _unbind, isBound) => {
   bind(ToolPalette).toSelf().inSingletonScope();
@@ -13,6 +14,7 @@ const ivyToolPaletteModule = new ContainerModule((bind, _unbind, isBound) => {
   configureActionHandler({ bind, isBound }, EnableToolPaletteAction.KIND, ToolPalette);
   configureActionHandler({ bind, isBound }, EnableDefaultToolsAction.KIND, ToolPalette);
   configureCommand({ bind, isBound }, ToolPaletteFeedbackCommand);
+  bind(GLSP_TYPES.ITool).to(IvyMarqueeMouseTool);
 });
 
 export default ivyToolPaletteModule;

--- a/editor/src/tool-palette/marquee-mouse-tool.ts
+++ b/editor/src/tool-palette/marquee-mouse-tool.ts
@@ -1,0 +1,15 @@
+import { injectable } from 'inversify';
+import { MarqueeMouseTool } from '@eclipse-glsp/client/lib/features/tools/marquee-mouse-tool';
+
+@injectable()
+export class IvyMarqueeMouseTool extends MarqueeMouseTool {
+  static ID = 'ivy.marquee-mouse-tool';
+
+  get id(): string {
+    return IvyMarqueeMouseTool.ID;
+  }
+
+  get isEditTool(): boolean {
+    return false;
+  }
+}

--- a/editor/src/viewport/scroll-mouse-listener.ts
+++ b/editor/src/viewport/scroll-mouse-listener.ts
@@ -1,11 +1,21 @@
-import { findParentByFeature, GLSPScrollMouseListener, SModelElement } from '@eclipse-glsp/client';
+import { findParentByFeature, GLSPScrollMouseListener, ICommand, SModelElement } from '@eclipse-glsp/client';
 import { injectable } from 'inversify';
-import { Action } from 'sprotty';
+import { Action, EnableToolsAction } from 'sprotty';
+import { IvyMarqueeMouseTool } from '../tool-palette/marquee-mouse-tool';
 
 import { isLaneResizeHandle } from '../lanes/model';
 
 @injectable()
 export class IvyScrollMouseListener extends GLSPScrollMouseListener {
+  handle(action: Action): void | Action | ICommand {
+    if (action instanceof EnableToolsAction) {
+      if (action.toolIds.includes(IvyMarqueeMouseTool.ID)) {
+        this.preventScrolling = true;
+      }
+    }
+    super.handle(action);
+  }
+
   mouseDown(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
     const lane = findParentByFeature(target, isLaneResizeHandle);
     if (lane) {

--- a/editor/tests/tool-palette/tool-palette-feedback.spec.ts
+++ b/editor/tests/tool-palette/tool-palette-feedback.spec.ts
@@ -16,7 +16,8 @@ import {
   SGraph,
   SModelFactory,
   SModelRoot,
-  TYPES
+  TYPES,
+  glspMouseToolModule
 } from '@eclipse-glsp/client';
 import { expect } from 'chai';
 import { Container, injectable } from 'inversify';
@@ -41,7 +42,7 @@ class ToolPaletteFeedbackCommandMock extends ToolPaletteFeedbackCommand {
 
 function createContainer(): Container {
   const container = new Container();
-  container.load(defaultModule, defaultGLSPModule, glspSelectModule, modelSourceModule, ivyToolPaletteModule);
+  container.load(defaultModule, defaultGLSPModule, glspSelectModule, modelSourceModule, glspMouseToolModule, ivyToolPaletteModule);
   container.bind(TYPES.ModelSource).to(LocalModelSource);
   container.bind(GLSP_TYPES.IFeedbackActionDispatcher).to(FeedbackActionDispatcher).inSingletonScope();
   container.bind(CustomIconToggleActionHandler).toSelf().inSingletonScope();

--- a/integration/eclipse/webview/src/open-inscription/quick-action.ts
+++ b/integration/eclipse/webview/src/open-inscription/quick-action.ts
@@ -19,6 +19,7 @@ class InscribeQuickAction implements QuickAction {
     public readonly title = 'Edit',
     public readonly location = QuickActionLocation.TopLeft,
     public readonly sorting = 'B',
-    public readonly action = new OpenAction(elementId)
+    public readonly action = new OpenAction(elementId),
+    public readonly readonlySupport = true
   ) {}
 }


### PR DESCRIPTION
- Enable toolpalette
  - Disable element picker palette)
  - Disable delete, wrap to sub, auto align btns
- Enable marquee mouse tool
- Hide operation quick-actions in readonly mode
- Test quick-actions in read-only mode