### PR TITLE
Add Quick-Actions Webtests

### DIFF
--- a/editor/src/diagram/activities/activity-views.tsx
+++ b/editor/src/diagram/activities/activity-views.tsx
@@ -53,7 +53,7 @@ export class SubActivityNodeView extends ActivityNodeView {
     const radius = diameter / 2;
     const padding = 2;
     return (
-      <svg x={node.bounds.width / 2 - radius} y={node.bounds.height - diameter}>
+      <svg x={node.bounds.width / 2 - radius} y={node.bounds.height - diameter} height={diameter} width={diameter}>
         <rect class-sprotty-node={true} class-sprotty-task-node={true} width={diameter} height={diameter} />
         <line class-sprotty-node-decorator x1={radius} y1={padding} x2={radius} y2={diameter - padding} />
         <line class-sprotty-node-decorator x1={padding} y1={radius} x2={diameter - padding} y2={radius} />

--- a/editor/tests/diagram/activities/activity-views.spec.tsx
+++ b/editor/tests/diagram/activities/activity-views.spec.tsx
@@ -135,7 +135,7 @@ describe('ActivityNodeView', () => {
     const vnode = view.render(graph.index.getById('subProcess') as SNode, context);
     const expectation =
       '<g><rect class="sprotty-node task" x="0" y="0" rx="5" ry="5" width="150" height="50" /><g></g>' +
-      '<svg x="70" y="40"><rect class="sprotty-node sprotty-task-node" width="10" height="10" />' +
+      '<svg x="70" y="40" height="10" width="10"><rect class="sprotty-node sprotty-task-node" width="10" height="10" />' +
       '<line class="sprotty-node-decorator" x1="5" y1="2" x2="5" y2="8" />' +
       '<line class="sprotty-node-decorator" x1="2" y1="5" x2="8" y2="5" /></svg></g>';
     expect(toHTML(vnode)).to.be.equal(expectation);
@@ -146,7 +146,7 @@ describe('ActivityNodeView', () => {
     const vnode = view.render(graph.index.getById('embeddedProcess') as SNode, context);
     const expectation =
       '<g><rect class="sprotty-node task" x="0" y="0" rx="5" ry="5" width="150" height="50" /><g></g>' +
-      '<svg x="70" y="40"><rect class="sprotty-node sprotty-task-node" width="10" height="10" />' +
+      '<svg x="70" y="40" height="10" width="10"><rect class="sprotty-node sprotty-task-node" width="10" height="10" />' +
       '<line class="sprotty-node-decorator" x1="5" y1="2" x2="5" y2="8" />' +
       '<line class="sprotty-node-decorator" x1="2" y1="5" x2="8" y2="5" /></svg></g>';
     expect(toHTML(vnode)).to.be.equal(expectation);

--- a/integration/standalone/webtests/diagram-util.ts
+++ b/integration/standalone/webtests/diagram-util.ts
@@ -1,7 +1,7 @@
 import { Locator, Page } from '@playwright/test';
 
 export async function multiSelect(page: Page, elements: Locator[]): Promise<void> {
-  await page.locator('.sprotty-graph').click({ position: { x: 0, y: 60 } });
+  await resetSelection(page);
   await page.keyboard.down('Control');
   for (const element of elements) {
     await element.click();
@@ -9,8 +9,33 @@ export async function multiSelect(page: Page, elements: Locator[]): Promise<void
   await page.keyboard.up('Control');
 }
 
+export async function resetSelection(page: Page): Promise<void> {
+  await page.locator('.sprotty-graph').click({ position: { x: 0, y: 60 } });
+}
+
+export async function cleanDiagram(page: Page): Promise<void> {
+  await page.locator('.sprotty-graph .start').click();
+  await page.keyboard.press('Delete');
+  await page.locator('.sprotty-graph .end').click();
+  await page.keyboard.press('Delete');
+}
+
+export async function addActivity(page: Page, activityName: string, xPos: number, yPos: number): Promise<void> {
+  await page.locator('#btn_ele_picker_activity-group').click();
+  await page.locator(`.element-palette-body .tool-button:has-text("${activityName}")`).click();
+  await page.locator('.sprotty-graph').click({ position: { x: xPos, y: yPos } });
+}
+
+export async function addPool(page: Page, yPos: number): Promise<void> {
+  createLane(page, 'Pool', yPos);
+}
+
 export async function addLane(page: Page, yPos: number): Promise<void> {
+  createLane(page, 'Lane', yPos);
+}
+
+async function createLane(page: Page, createBtn: string, yPos: number): Promise<void> {
   await page.locator('#btn_ele_picker_swimlane-group').click();
-  await page.locator('.element-palette-body .tool-button:has-text("Lane")').click();
+  await page.locator(`.element-palette-body .tool-button:has-text("${createBtn}")`).click();
   await page.locator('.sprotty-graph').click({ position: { x: 10, y: yPos } });
 }

--- a/integration/standalone/webtests/diagram/diagram.spec.ts
+++ b/integration/standalone/webtests/diagram/diagram.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { procurementRequestParallelUrl } from './process-editor-url-util';
+import { procurementRequestParallelUrl } from '../process-editor-url-util';
 
 test('open process editor', async ({ page }) => {
   await page.goto(procurementRequestParallelUrl());

--- a/integration/standalone/webtests/quick-actions/connector.spec.ts
+++ b/integration/standalone/webtests/quick-actions/connector.spec.ts
@@ -1,0 +1,64 @@
+import { expect, Locator, Page, test } from '@playwright/test';
+import { resetSelection } from '../diagram-util';
+import { randomTestProcessUrl } from '../process-editor-url-util';
+import { assertQuickActionsCount, clickQuickAction, editLabel } from './quick-actions-util';
+
+test.describe('quick actions - connectors', () => {
+  const STRAIGHT_CONNECTOR_PATH = /M \d+.?\d*,\d+.?\d* L \d+.?\d*,\d+.?\d*/;
+  const BEND_CONNECTOR_PATH = /M \d+,\d+ L \d+,\d+ L \d+,\d+ L \d+,\d+/;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(randomTestProcessUrl());
+  });
+
+  test('connector actions', async ({ page }) => {
+    const connector = page.locator('.sprotty-graph > g > .sprotty-edge');
+
+    await assertQuickActionsCount(page, 0);
+    await connector.click();
+    await assertQuickActionsCount(page, 4);
+  });
+
+  test('connector label edit', async ({ page }) => {
+    const connector = page.locator('.sprotty-graph > g > .sprotty-edge');
+    await editConnectorLabel(page, connector);
+  });
+
+  test('connector delete', async ({ page }) => {
+    const connector = page.locator('.sprotty-graph > g > .sprotty-edge');
+    await deleteConnector(page, connector);
+    await expect(connector).not.toBeVisible();
+  });
+
+  test('connector bend and straigthen', async ({ page }) => {
+    const endElement = page.locator('.sprotty-graph .end');
+    await endElement.dragTo(page.locator('.sprotty-graph'));
+    const connector = page.locator('.sprotty-graph > g > .sprotty-edge');
+    const connectorPath = page.locator('.sprotty-graph > g > .sprotty-edge > path').first();
+    await expect(connectorPath).toHaveAttribute('d', STRAIGHT_CONNECTOR_PATH);
+
+    await connector.click();
+    await clickQuickAction(page, 'Straighten');
+    await expect(connectorPath).toHaveAttribute('d', STRAIGHT_CONNECTOR_PATH);
+
+    await resetSelection(page);
+    await connector.click();
+    await clickQuickAction(page, 'Bend');
+    await expect(connectorPath).toHaveAttribute('d', BEND_CONNECTOR_PATH);
+
+    await resetSelection(page);
+    await connector.click();
+    await clickQuickAction(page, 'Straighten');
+    await expect(connectorPath).toHaveAttribute('d', STRAIGHT_CONNECTOR_PATH);
+  });
+
+  async function editConnectorLabel(page: Page, connector: Locator): Promise<void> {
+    editLabel(page, connector);
+    await expect(connector.locator('.sprotty-label div')).toHaveText('test label');
+  }
+
+  async function deleteConnector(page: Page, connector: Locator): Promise<void> {
+    await connector.click();
+    await clickQuickAction(page, 'Delete');
+  }
+});

--- a/integration/standalone/webtests/quick-actions/lane.spec.ts
+++ b/integration/standalone/webtests/quick-actions/lane.spec.ts
@@ -1,0 +1,91 @@
+import { expect, Locator, Page, test } from '@playwright/test';
+import { addLane, addPool } from '../diagram-util';
+import { randomTestProcessUrl } from '../process-editor-url-util';
+import { assertQuickActionsCount, clickQuickAction, clickQuickActionStartsWith, editLabel } from './quick-actions-util';
+
+test.describe('quick actions - lanes', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(randomTestProcessUrl());
+  });
+
+  test('root lane actions', async ({ page }) => {
+    const lane = page.locator('.sprotty-graph .lane');
+    await addLane(page, 60);
+
+    await assertQuickActionsCount(page, 0);
+    await lane.click();
+    await assertQuickActionsCount(page, 2);
+  });
+
+  test('root lane label', async ({ page }) => {
+    const lane = page.locator('.sprotty-graph .lane');
+    await addLane(page, 60);
+    await editLaneLabel(page, lane);
+  });
+
+  test('root lane delete', async ({ page }) => {
+    const lane = page.locator('.sprotty-graph .lane');
+    await addLane(page, 60);
+
+    await deleteLane(page, lane);
+    await expect(lane).not.toBeVisible();
+  });
+
+  test('pool actions', async ({ page }) => {
+    const pool = page.locator('.sprotty-graph .pool');
+    await addPool(page, 60);
+
+    await assertQuickActionsCount(page, 0);
+    await pool.click();
+    await assertQuickActionsCount(page, 3);
+  });
+
+  test('pool label', async ({ page }) => {
+    const processName = page.url().substring(page.url().lastIndexOf('/') + 1, page.url().lastIndexOf('.'));
+    const pool = page.locator('.sprotty-graph .pool');
+    await addPool(page, 60);
+    await expect(pool.locator('text tspan')).toHaveText(processName);
+    await editLaneLabel(page, pool);
+  });
+
+  test('pool delete', async ({ page }) => {
+    const pool = page.locator('.sprotty-graph .pool');
+    await addPool(page, 60);
+    await deleteLane(page, pool);
+    await expect(pool).not.toBeVisible();
+  });
+
+  test('pool add and remove embedded lanes', async ({ page }) => {
+    const pool = page.locator('.sprotty-graph .pool');
+    const embeddedLanes = page.locator('.sprotty-graph .pool > .lane');
+    await addPool(page, 60);
+
+    await createEmbeddedLane(page, pool);
+    await expect(embeddedLanes).toHaveCount(1);
+
+    await createEmbeddedLane(page, pool);
+    await expect(embeddedLanes).toHaveCount(2);
+
+    await deleteLane(page, embeddedLanes.first());
+    await expect(embeddedLanes).toHaveCount(1);
+
+    await deleteLane(page, pool);
+    await expect(embeddedLanes).toHaveCount(0);
+    await expect(pool).not.toBeVisible();
+  });
+
+  async function createEmbeddedLane(page: Page, pool: Locator): Promise<void> {
+    await pool.click({ position: { x: 5, y: 100 } });
+    await clickQuickActionStartsWith(page, 'Create');
+  }
+
+  async function deleteLane(page: Page, lane: Locator): Promise<void> {
+    await lane.click({ position: { x: 5, y: 100 } });
+    await clickQuickAction(page, 'Delete');
+  }
+
+  async function editLaneLabel(page: Page, lane: Locator): Promise<void> {
+    editLabel(page, lane);
+    await expect(lane.locator('text tspan')).toHaveText('test label');
+  }
+});

--- a/integration/standalone/webtests/quick-actions/node.spec.ts
+++ b/integration/standalone/webtests/quick-actions/node.spec.ts
@@ -1,0 +1,145 @@
+import { expect, Locator, Page, test } from '@playwright/test';
+import { addActivity, multiSelect } from '../diagram-util';
+import { randomTestProcessUrl } from '../process-editor-url-util';
+import { clickQuickAction, clickQuickActionEndsWith, clickQuickActionStartsWith, editLabel, assertQuickActionsCount } from './quick-actions-util';
+
+test.describe('quick actions - nodes', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(randomTestProcessUrl());
+  });
+
+  test('event actions', async ({ page }) => {
+    const start = page.locator('.sprotty-graph .start');
+    const end = page.locator('.sprotty-graph .end');
+
+    await assertQuickActionsCount(page, 0);
+    await start.click();
+    await assertQuickActionsCount(page, 4);
+    await end.click();
+    await assertQuickActionsCount(page, 3);
+  });
+
+  test('label edit', async ({ page }) => {
+    const start = page.locator('.sprotty-graph .start');
+    await expect(start.locator('.sprotty-label div')).toHaveText('start.ivp');
+    await editNodeLabel(page, start);
+  });
+
+  test('delete', async ({ page }) => {
+    const start = page.locator('.sprotty-graph .start');
+    await deleteNode(page, start);
+    await expect(start).not.toBeVisible();
+  });
+
+  test('attach comment', async ({ page }) => {
+    const end = page.locator('.sprotty-graph .end');
+    const comment = page.locator('.sprotty-graph .comment');
+    const connectors = page.locator('.sprotty-graph > g > .sprotty-edge');
+    await expect(comment).not.toBeVisible();
+    await expect(connectors).toHaveCount(1);
+
+    await end.dragTo(page.locator('.sprotty-graph'));
+    await end.click();
+    await clickQuickActionEndsWith(page, 'Comment');
+    await expect(comment).toBeVisible();
+    await expect(connectors).toHaveCount(2);
+  });
+
+  test('connect', async ({ page }) => {
+    const start = page.locator('.sprotty-graph .start');
+    const end = page.locator('.sprotty-graph .end');
+    const connector = page.locator('.sprotty-graph > g > .sprotty-edge:not(.feedback-edge)');
+    const connectorFeedback = page.locator('.sprotty-graph > g > .sprotty-edge.feedback-edge');
+    await connector.click();
+    await page.keyboard.press('Delete');
+
+    await start.click();
+    await clickQuickAction(page, 'Connect');
+    await expect(connectorFeedback).toBeVisible();
+    await expect(connector).not.toBeVisible();
+
+    await end.click();
+    await expect(connectorFeedback).not.toBeVisible();
+    await expect(connector).toBeVisible();
+  });
+
+  test('error boundary', async ({ page }) => {
+    addActivity(page, 'User Dialog', 200, 200);
+    const hd = page.locator('.sprotty-graph .hd');
+    const errorBoundary = page.locator('.sprotty-graph .boundary\\:error');
+    await expect(errorBoundary).toBeHidden();
+
+    await hd.click();
+    await clickQuickActionEndsWith(page, 'Error');
+    await expect(errorBoundary).toBeVisible();
+  });
+
+  test('signal boundary', async ({ page }) => {
+    addActivity(page, 'User Task', 200, 200);
+    const userTask = page.locator('.sprotty-graph .user');
+    const signalBoundary = page.locator('.sprotty-graph .boundary\\:signal');
+    await expect(signalBoundary).toBeHidden();
+
+    await userTask.click();
+    await clickQuickActionEndsWith(page, 'Signal');
+    await expect(signalBoundary).toBeVisible();
+  });
+
+  test('auto align', async ({ page, browserName }) => {
+    test.skip(browserName === 'webkit', 'Webkit browser has problems with Ctrl multiselect');
+    const start = page.locator('.sprotty-graph .start');
+    const end = page.locator('.sprotty-graph .end');
+    await end.dragTo(page.locator('.sprotty-graph'));
+    const startTransform = await start.getAttribute('transform');
+    const endTransform = await end.getAttribute('transform');
+
+    await multiSelect(page, [start, end]);
+    await clickQuickActionEndsWith(page, 'Align');
+    await expect(start).toHaveAttribute('transform', startTransform);
+    await expect(end).not.toHaveAttribute('transform', endTransform);
+    // end element should only be moved vertically
+    await expect(end).toHaveAttribute('transform', /translate\(625, \d+\)/);
+  });
+
+  test('wrap, jump and unwrap', async ({ page, browserName }) => {
+    test.skip(browserName === 'webkit', 'Webkit browser has problems with Ctrl multiselect');
+    const jumpOutBtn = page.locator('.dynamic-tools i[title^="Jump"]');
+    const start = page.locator('.sprotty-graph .start');
+    const end = page.locator('.sprotty-graph .end');
+    const embedded = page.locator('.sprotty-graph .embeddedproc');
+
+    await multiSelect(page, [start, end]);
+    await clickQuickActionStartsWith(page, 'Wrap');
+    await expect(start).toBeHidden();
+    await expect(end).toBeHidden();
+    await expect(embedded).toBeVisible();
+
+    await embedded.click();
+    await clickQuickAction(page, 'Jump');
+    await expect(start).toBeVisible();
+    await expect(end).toBeVisible();
+    await expect(embedded).toBeHidden();
+    await expect(jumpOutBtn).toBeVisible();
+
+    await jumpOutBtn.click();
+    await expect(start).toBeHidden();
+    await expect(end).toBeHidden();
+    await expect(embedded).toBeVisible();
+
+    await embedded.click();
+    await clickQuickActionStartsWith(page, 'Unwrap');
+    await expect(start).toBeVisible();
+    await expect(end).toBeVisible();
+    await expect(embedded).toBeHidden();
+  });
+
+  async function editNodeLabel(page: Page, node: Locator): Promise<void> {
+    editLabel(page, node);
+    await expect(node.locator('.sprotty-label div')).toHaveText('test label');
+  }
+
+  async function deleteNode(page: Page, node: Locator): Promise<void> {
+    await node.click();
+    await clickQuickAction(page, 'Delete');
+  }
+});

--- a/integration/standalone/webtests/quick-actions/quick-actions-util.ts
+++ b/integration/standalone/webtests/quick-actions/quick-actions-util.ts
@@ -1,0 +1,26 @@
+import { expect, Locator, Page } from '@playwright/test';
+
+export async function editLabel(page: Page, element: Locator): Promise<void> {
+  const label = page.locator('#sprotty_editLabelUi textarea');
+  await element.click();
+  await clickQuickActionEndsWith(page, 'Label');
+  await expect(label).toBeVisible();
+  await label.fill('test label');
+  await page.keyboard.press('Enter');
+}
+
+export async function assertQuickActionsCount(page: Page, count: number): Promise<void> {
+  await expect(page.locator('#sprotty_quickActionsUi i')).toHaveCount(count);
+}
+
+export async function clickQuickAction(page: Page, title: string): Promise<void> {
+  await page.locator(`#sprotty_quickActionsUi i[title="${title}"]`).click();
+}
+
+export async function clickQuickActionStartsWith(page: Page, startsWithTitle: string): Promise<void> {
+  await page.locator(`#sprotty_quickActionsUi i[title^="${startsWithTitle}"]`).click();
+}
+
+export async function clickQuickActionEndsWith(page: Page, endsWithTitle: string): Promise<void> {
+  await page.locator(`#sprotty_quickActionsUi i[title$="${endsWithTitle}"]`).click();
+}

--- a/integration/standalone/webtests/tool-bar/dynamic-tools.spec.ts
+++ b/integration/standalone/webtests/tool-bar/dynamic-tools.spec.ts
@@ -79,7 +79,7 @@ test.describe('tool bar - dynamic tools', () => {
 
     await expect(startElement).toHaveAttribute('transform', startElementTransform);
     await expect(endElement).not.toHaveAttribute('transform', endElementTransform);
-    // end element should only be moved horizontally
+    // end element should only be moved vertically
     await expect(endElement).toHaveAttribute('transform', /translate\(625, \d+\)/);
   });
 });


### PR DESCRIPTION
Webtests for:

- Connectors quick-actions
- Lanes/Pools quick-actions
- Nodes (Events, Activities) quick-actions
- Create all elements from the palette