### PR TITLE
Open toolbar groups using single click.

### DIFF
--- a/editor/src/tool-bar/item-picker-menu.ts
+++ b/editor/src/tool-bar/item-picker-menu.ts
@@ -175,7 +175,7 @@ export class ItemPickerMenu {
       header.appendChild(createIcon([resolvePaletteIcon(item.icon).res]));
     }
     header.insertAdjacentText('beforeend', item.label);
-    header.ondblclick = _ev => {
+    header.onclick = _ev => {
       changeCSSClass(group, COLLAPSED_CSS);
       window!.getSelection()!.removeAllRanges();
     };


### PR DESCRIPTION
@ivy-lli any reason why a double click is needed to open the groups?

![image](https://user-images.githubusercontent.com/93579455/165904860-182e3988-dccc-403f-a595-bc8b7d1c3908.png)