### PR TITLE
XIVY-7811 Improve edit color dialog

### DIFF
--- a/editor/css/diagram.css
+++ b/editor/css/diagram.css
@@ -146,12 +146,10 @@ g[class^='end'] .sprotty-node {
 /* Icon / Label*/
 .sprotty-label {
   font-size: 12px;
-  user-select: none;
   cursor: pointer;
 }
 .sprotty-icon {
   border-radius: 3px;
-  user-select: none;
   cursor: pointer;
 }
 .sprotty-icon i {
@@ -202,7 +200,7 @@ g[class^='end'] .sprotty-node {
 }
 
 /* Comments */
-.comment .sprotty-node,
+.processAnnotation .sprotty-node,
 .association.sprotty-edge {
   stroke-dasharray: 5, 5;
 }

--- a/editor/css/tool-bar.css
+++ b/editor/css/tool-bar.css
@@ -157,9 +157,11 @@
   top: 1px;
   position: relative;
 }
-.tool-button .color-icon {
+.tool-button .color-icon,
+.color-palette-body .tool-button .empty-icon {
   height: 1em;
   border: 1px solid var(--glsp-tool-bar-forground);
+  background-color: var(--glsp-editor-foreground);
 }
 
 .collapsible-palette {
@@ -214,6 +216,14 @@ i.edit-item-button:hover {
   gap: 1rem;
   align-items: center;
   justify-content: space-between;
+}
+.edit-color-dialog .edit-color-input input {
+  border: 1px solid;
+  background-color: var(--glsp-editor-background);
+  color: var(--glsp-editor-foreground);
+}
+.edit-color-dialog .edit-color-input input.error {
+  border-color: var(--glsp-error-foreground);
 }
 .edit-color-dialog .edit-color-input input:not([type='color']) {
   width: 100%;

--- a/editor/src/tool-bar/action.ts
+++ b/editor/src/tool-bar/action.ts
@@ -1,18 +1,7 @@
 import { Action } from '@eclipse-glsp/protocol';
 
-export class ChangeColorAction implements Action {
-  static readonly KIND = 'changeColor';
-
-  constructor(
-    public readonly color: string,
-    public readonly colorName: string,
-    public readonly oldColor: string,
-    public readonly kind: string = ChangeColorAction.KIND
-  ) {}
-}
-
 export class UpdateColorPaletteAction implements Action {
   static readonly KIND = 'updateColorPalette';
 
-  constructor(public readonly kind: string = ChangeColorAction.KIND) {}
+  constructor(public readonly kind: string = UpdateColorPaletteAction.KIND) {}
 }

--- a/editor/src/tool-bar/edit-dialog.ts
+++ b/editor/src/tool-bar/edit-dialog.ts
@@ -4,6 +4,9 @@ export class EditDialog {
   public static DIALOG_CLOSE = 'close';
   public static DIALOG_CONFIRM = 'confirm';
   public static DIALOG_DELETE = 'delete';
+  private static NAME_INPUT_ID = 'editInputName';
+  private static COLOR_INPUT_ID = 'editInputColor';
+
   private dialog: HTMLElement;
   private handleDialogClose: (returnValue: string, formData: FormData, item?: PaletteItem | undefined) => void;
   private item: PaletteItem | undefined;
@@ -14,6 +17,7 @@ export class EditDialog {
   }
 
   dialogClosed = ({ target: dialog }: any): void => {
+    console.log(dialog);
     const dialogFormData = new FormData(dialog.querySelector('form'));
     this.handleDialogClose(dialog.returnValue, dialogFormData, this.item);
     dialog.querySelector('form')?.reset();
@@ -22,8 +26,8 @@ export class EditDialog {
   public showDialog(handleDialogClose: (returnValue: string, formData: FormData, item?: PaletteItem) => void, item?: PaletteItem): void {
     this.handleDialogClose = handleDialogClose;
     this.item = item;
-    this.setInputValue('editInputName', item?.label ?? '');
-    this.setInputValue('editInputColor', item?.icon ?? '');
+    this.setInputValue(EditDialog.NAME_INPUT_ID, item?.label ?? '');
+    this.setInputValue(EditDialog.COLOR_INPUT_ID, item?.icon ?? '');
     const deleteBtn = this.dialog.querySelector('.edit-color-delete-btn') as HTMLElement;
     if (deleteBtn) {
       deleteBtn.style.display = item ? 'block' : 'none';
@@ -36,6 +40,10 @@ export class EditDialog {
     if (input) {
       input.value = value;
     }
+  }
+
+  private getInputElement(id: string): HTMLInputElement | undefined {
+    return this.dialog.querySelector(`#${id}`) as HTMLInputElement;
   }
 
   private createEditDialog(containerElement: HTMLElement): HTMLElement {
@@ -54,13 +62,12 @@ export class EditDialog {
   private createDialogBody(): HTMLElement {
     const body = document.createElement('div');
     body.classList.add('edit-color-body');
-    body.appendChild(this.createInput('Name'));
-    body.appendChild(this.createInput('Color', true));
+    body.appendChild(this.createInput(EditDialog.NAME_INPUT_ID, 'Name'));
+    body.appendChild(this.createInput(EditDialog.COLOR_INPUT_ID, 'Color', true));
     return body;
   }
 
-  private createInput(labelText: string, showColorPicker = false): HTMLElement {
-    const id = `editInput${labelText}`;
+  private createInput(id: string, labelText: string, showColorPicker = false): HTMLElement {
     const div = document.createElement('div');
     div.classList.add('edit-color-input');
     const label = document.createElement('label') as HTMLLabelElement;
@@ -99,12 +106,33 @@ export class EditDialog {
     cancelBtn.onclick = e => (this.dialog as any).close(EditDialog.DIALOG_CLOSE);
     const confirmBtn = document.createElement('button');
     confirmBtn.classList.add('edit-color-confirm-btn');
-    confirmBtn.textContent = 'Confirm';
-    confirmBtn.type = 'submit';
-    confirmBtn.value = EditDialog.DIALOG_CONFIRM;
+    confirmBtn.textContent = 'Ok';
+    confirmBtn.type = 'button';
+    confirmBtn.onclick = e => this.validateInputsAndRun(() => (this.dialog as any).close(EditDialog.DIALOG_CONFIRM));
     footer.appendChild(deleteBtn);
     footer.appendChild(cancelBtn);
     footer.appendChild(confirmBtn);
     return footer;
+  }
+
+  private validateInputsAndRun(callable: () => void): void {
+    const validNameInput = this.validateInput(EditDialog.NAME_INPUT_ID);
+    const validColorInput = this.validateInput(EditDialog.COLOR_INPUT_ID);
+    if (validNameInput && validColorInput) {
+      callable();
+    }
+  }
+
+  private validateInput(inputId: string): boolean {
+    const input = this.getInputElement(inputId);
+    if (input) {
+      if (input.value === '') {
+        input.classList.add('error');
+        return false;
+      } else {
+        input.classList.remove('error');
+      }
+    }
+    return true;
   }
 }

--- a/editor/src/tool-bar/item-picker-menu.ts
+++ b/editor/src/tool-bar/item-picker-menu.ts
@@ -149,7 +149,7 @@ export class ItemPickerMenu {
     button.appendChild(this.appendPaletteIcon(button, item));
     button.insertAdjacentText('beforeend', item.label);
     if (this.handleEditDialogClose && item.label !== 'Default') {
-      button.appendChild(this.createEditButton('fa-pencil', item));
+      button.appendChild(this.createEditButton('fa-pencil', 'Edit Color', item));
     }
     button.onclick = (ev: MouseEvent) => this.onClickElementPickerToolButton(button, this.actions(item));
     button.onkeydown = ev => this.clearToolOnEscape(ev);
@@ -177,7 +177,9 @@ export class ItemPickerMenu {
         return span;
       }
     }
-    return document.createElement('span');
+    const emptyIcon = document.createElement('span');
+    emptyIcon.classList.add('empty-icon');
+    return emptyIcon;
   }
 
   private createToolGroup(item: PaletteItem): HTMLElement {
@@ -191,7 +193,7 @@ export class ItemPickerMenu {
     }
     header.insertAdjacentText('beforeend', item.label);
     if (this.handleEditDialogClose) {
-      header.appendChild(this.createEditButton('fa-add'));
+      header.appendChild(this.createEditButton('fa-add', 'Add Color'));
     }
     header.onclick = _ev => {
       changeCSSClass(group, COLLAPSED_CSS);
@@ -202,8 +204,9 @@ export class ItemPickerMenu {
     return group;
   }
 
-  private createEditButton(icon: string, item?: PaletteItem): HTMLElement {
+  private createEditButton(icon: string, title: string, item?: PaletteItem): HTMLElement {
     const editButton = createIcon(['fa-solid', icon, 'edit-item-button']);
+    editButton.title = title;
     editButton.onclick = (ev: MouseEvent) => {
       ev.stopPropagation();
       this.editDialog?.showDialog(this.handleEditDialogClose!, item);

--- a/editor/src/tool-bar/operation.ts
+++ b/editor/src/tool-bar/operation.ts
@@ -26,3 +26,14 @@ export class ChangeActivityTypeOperation implements Operation {
     public readonly kind: string = ChangeActivityTypeOperation.KIND
   ) {}
 }
+
+export class ChangeColorOperation implements Operation {
+  static readonly KIND = 'changeColor';
+
+  constructor(
+    public readonly color: string,
+    public readonly colorName: string,
+    public readonly oldColor: string,
+    public readonly kind: string = ChangeColorOperation.KIND
+  ) {}
+}

--- a/editor/src/tool-bar/tool-bar.ts
+++ b/editor/src/tool-bar/tool-bar.ts
@@ -142,16 +142,15 @@ export class ToolBar extends AbstractUIExtension implements IActionHandler, Edit
   private createToolBarButtons(containerElement: HTMLElement, toolBarButtons: ToolBarButton[]): void {
     toolBarButtons
       .sort((a, b) => a.sorting.localeCompare(b.sorting))
-      .forEach(button => {
-        const htmlButton = document.createElement('span');
-        htmlButton.appendChild(createIcon([button.icon, 'fa-xs']));
-        htmlButton.title = button.title;
-        this.showDynamicBtn(htmlButton, button.visible);
-        htmlButton.onclick = _event => this.dispatchAction([button.action()]);
-        if (button.id) {
-          htmlButton.id = button.id;
+      .forEach(toolbarButton => {
+        const button = createIcon([toolbarButton.icon, 'fa-xs']);
+        button.title = toolbarButton.title;
+        this.showDynamicBtn(button, toolbarButton.visible);
+        button.onclick = _event => this.dispatchAction([toolbarButton.action()]);
+        if (toolbarButton.id) {
+          button.id = toolbarButton.id;
         }
-        containerElement.appendChild(htmlButton);
+        containerElement.appendChild(button);
       });
   }
 

--- a/editor/src/tool-bar/tool-bar.ts
+++ b/editor/src/tool-bar/tool-bar.ts
@@ -33,7 +33,7 @@ import { QuickActionUI } from '../quick-action/quick-action-ui';
 
 import { CustomIconToggleAction } from '../diagram/icon/custom-icon-toggle-action-handler';
 import { IvyMarqueeMouseTool } from './marquee-mouse-tool';
-import { ChangeActivityTypeOperation, ColorizeOperation } from './operation';
+import { ChangeActivityTypeOperation, ChangeColorOperation, ColorizeOperation } from './operation';
 import { ToolBarFeedbackAction } from './tool-bar-feedback';
 import { compare, createIcon } from './tool-bar-helper';
 import { ItemPickerMenu } from './item-picker-menu';
@@ -50,7 +50,7 @@ import {
 } from './button';
 import { resolvePaletteIcon } from '../diagram/icon/icons';
 import { EditDialog } from './edit-dialog';
-import { ChangeColorAction, UpdateColorPaletteAction } from './action';
+import { UpdateColorPaletteAction } from './action';
 
 const CLICKED_CSS_CLASS = 'clicked';
 
@@ -282,7 +282,7 @@ export class ToolBar extends AbstractUIExtension implements IActionHandler, Edit
       colorName = newColor.Name.toString();
       color = newColor.Color.toString();
     }
-    this.actionDispatcher.dispatch(new ChangeColorAction(color, colorName, oldColor));
+    this.actionDispatcher.dispatch(new ChangeColorOperation(color, colorName, oldColor));
   };
 
   changeActiveButton(button?: HTMLElement): void {

--- a/integration/standalone/webtests/key-listener/quick-action.spec.ts
+++ b/integration/standalone/webtests/key-listener/quick-action.spec.ts
@@ -60,7 +60,7 @@ test.describe('key listener - quick action shortcuts', () => {
   });
 
   test('wrap, jump and unwrap', async ({ page, browserName }) => {
-    const jumpOutBtn = page.locator('.dynamic-tools span[title^="Jump"]');
+    const jumpOutBtn = page.locator('.dynamic-tools i[title^="Jump"]');
     const start = page.locator(startSelector);
     const end = page.locator(endSelector);
     const embedded = page.locator(embeddedSelector);

--- a/integration/standalone/webtests/process-editor-url-util.ts
+++ b/integration/standalone/webtests/process-editor-url-util.ts
@@ -14,6 +14,13 @@ export function serverUrl(): string {
 }
 
 export async function gotoRandomTestProcessUrl(page: Page): Promise<void> {
+  // Log websocket communications:
+  // page.on('websocket', ws => {
+  //   console.log(`WebSocket opened: ${ws.url()}>`);
+  //   ws.on('framesent', event => console.log('>> sent: ' + event.payload));
+  //   ws.on('framereceived', event => console.log('<< recv: ' + event.payload));
+  //   ws.on('close', () => console.log('WebSocket closed'));
+  // });
   await page.goto(randomTestProcessUrl());
   const start = page.locator(startSelector);
   // wait for start element, give a reload if was not visible the first time

--- a/integration/standalone/webtests/quick-actions/node.spec.ts
+++ b/integration/standalone/webtests/quick-actions/node.spec.ts
@@ -101,7 +101,7 @@ test.describe('quick actions - nodes', () => {
   });
 
   test('wrap, jump and unwrap', async ({ page, browserName }) => {
-    const jumpOutBtn = page.locator('.dynamic-tools span[title^="Jump"]');
+    const jumpOutBtn = page.locator('.dynamic-tools i[title^="Jump"]');
     const start = page.locator(startSelector);
     const end = page.locator(endSelector);
     const embedded = page.locator(embeddedSelector);

--- a/integration/standalone/webtests/tool-bar/dynamic-tools.spec.ts
+++ b/integration/standalone/webtests/tool-bar/dynamic-tools.spec.ts
@@ -10,7 +10,7 @@ test.describe('tool bar - dynamic tools', () => {
   test('delete', async ({ page }) => {
     const dynamicTools = page.locator('.dynamic-tools');
     const startElement = page.locator(startSelector);
-    const deleteBtn = dynamicTools.locator('span[title=Delete]');
+    const deleteBtn = dynamicTools.locator('i[title=Delete]');
     await expect(dynamicTools).not.toBeVisible();
     await startElement.click();
 
@@ -24,7 +24,7 @@ test.describe('tool bar - dynamic tools', () => {
   test('wrap single to sub', async ({ page }) => {
     const dynamicTools = page.locator('.dynamic-tools');
     const startElement = page.locator(startSelector);
-    const wrapToSubBtn = dynamicTools.locator('span[title^=Wrap]');
+    const wrapToSubBtn = dynamicTools.locator('i[title^=Wrap]');
     const embeddedElements = page.locator(embeddedSelector);
     await expect(dynamicTools).not.toBeVisible();
     await expect(embeddedElements).toHaveCount(0);
@@ -42,7 +42,7 @@ test.describe('tool bar - dynamic tools', () => {
     const dynamicTools = page.locator('.dynamic-tools');
     const startElement = page.locator(startSelector);
     const endElement = page.locator(endSelector);
-    const wrapToSubBtn = dynamicTools.locator('span[title^=Wrap]');
+    const wrapToSubBtn = dynamicTools.locator('i[title^=Wrap]');
     const embeddedElements = page.locator(embeddedSelector);
     await expect(dynamicTools).not.toBeVisible();
     await expect(embeddedElements).toHaveCount(0);
@@ -62,7 +62,7 @@ test.describe('tool bar - dynamic tools', () => {
     const dynamicTools = page.locator('.dynamic-tools');
     const startElement = page.locator(startSelector);
     const endElement = page.locator(endSelector);
-    const autoAlignBtn = dynamicTools.locator('span[title^=Auto]');
+    const autoAlignBtn = dynamicTools.locator('i[title^=Auto]');
     await expect(dynamicTools).not.toBeVisible();
 
     await endElement.dragTo(page.locator('.sprotty-graph'));

--- a/integration/standalone/webtests/tool-bar/type-palette.spec.ts
+++ b/integration/standalone/webtests/tool-bar/type-palette.spec.ts
@@ -74,7 +74,7 @@ test.describe('tool bar - BPMN type palette', () => {
     const dynamicTools = page.locator('.dynamic-tools');
     const typePaletteBtn = dynamicTools.locator('i[title$=Type]');
     const toolButtons = page.locator(PALETTE_BODY + ' .tool-button');
-    const jumpOutBtn = page.locator('.dynamic-tools span[title^="Jump"]');
+    const jumpOutBtn = page.locator('.dynamic-tools i[title^="Jump"]');
     const manual = page.locator('.sprotty-graph .manualBpmnElement');
     const embedded = page.locator(embeddedSelector);
 


### PR DESCRIPTION
- Validate empty input fields -> error if empty
- Rename confirm btn -> "Ok"
- Tooltip for edit/add btn
- Add color-icon to default color
- Change color action to operation
- Fix tests and add one for validate color dialog